### PR TITLE
Don't update the DOM if the toggle has been removed

### DIFF
--- a/addon/components/x-toggle.js
+++ b/addon/components/x-toggle.js
@@ -54,6 +54,9 @@ export default class XToggle extends Component {
 
   @action
   toggleSwitch(value) {
+    // Prevent re-renders when the element is cleaning up (which cause errors).
+    if (this.isDestroyed || this.isDestroying) return
+
     let onToggle = this.args.onToggle;
     let disabled = this.disabled;
 


### PR DESCRIPTION
Currently, if the toggle causes the element to be removed from the DOM, the code that updates the DOM fails with `TypeError: Cannot read property 'querySelector' of null`